### PR TITLE
Cleanup chunks only when rescuing from an error

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -209,8 +209,8 @@
 
             file.save!
             file
-          ensure
-            chunks.each{|chunk| chunk.destroy rescue nil} if $!
+          rescue
+            chunks.each{|chunk| chunk.destroy rescue nil}
           end
 
           if defined?(Moped)


### PR DESCRIPTION
Relying on the `$!` variable to made it possible to unintentionally destroy chunks during a successful pass if the `$!` variable was set by something else upstream.

E.g. `$!` is set to an EOFError under the Pow server, because the Nack server runs everything through an (expected) `EOFError` rescue block:

https://github.com/josh/nack/blob/master/lib/nack/server.rb#L98-L101

Fixes #7
