### PR TITLE
Added support for bundler (Gemfile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/
 test/db.yml
 TODO
 *.sw*
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails"
+
+gemspec


### PR DESCRIPTION
Makes it easier for others to contribute without having to hunt for dependencies to get the tests to pass. Ideally, this Gemfile would be just a `gemspec` declaration, but that would require `add_development_dependency` declarations in the gemspec. Unfortunately, the gemspec generation is coupled to the Rakefile and the library itself, which makes the addition of development dependencies worthy of a separate pull-request in itself.
