### PR TITLE
Error 10128 when reading file of more than 50mb

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -212,6 +212,7 @@
             file
           rescue
             chunks.each{|chunk| chunk.destroy rescue nil}
+            raise $!
           end
 
           if defined?(Moped)


### PR DESCRIPTION
Ran into the following error when attempting to read file of more than 50mb (estimated):

```
[2013-04-05 15:29:36] ERROR Moped::Errors::QueryFailure: The operation: #<Moped::Protocol::Query
  @length=144  
  @request_id=4 
  @response_to=0
  @op_code=2004     
  @flags=[:slave_ok]                                
  @full_collection_name="mayday_store_dev.fs.chunks"
  @skip=0 
  @limit=0                                                                                                        
  @selector={"$query"=>{"files_id"=>"515e7d5fc5fe824fdb000001", "n"=>{"$lt"=>9, "$gte"=>0}}, "$orderby"=>{"n"=>1}}
  @fields=nil>                                                                                             
failed with error 10128: "too much data for sort() with no index.  add an index or specify a smaller limit"
See https://github.com/mongodb/mongo/blob/master/docs/errors.md
```
