### PR TITLE
Fix failing test: having file size more than 42mb

### DIFF
--- a/test/mongoid-grid_fs_test.rb
+++ b/test/mongoid-grid_fs_test.rb
@@ -170,7 +170,7 @@ Testing Mongoid::GridFs do
         Tempfile.new("mongoid-grid_fs~43mb.#{suffix}")
       end
 
-      assert system("dd if=/dev/zero of=#{orig.path} bs=43m count=1 &> /dev/null")
+      assert system("dd if=/dev/zero of=#{orig.path} bs=43M count=1 &> /dev/null")
 
       GridFs.get(GridFs.put(orig.path).id).each do |chunk|
         copy.print(chunk.to_s)


### PR DESCRIPTION
This is small typo fixation. Currently, the test results are:

```
$ bundle exec rake test

=======================================================================================================================
@1 => ruby -I ./lib -I ./test/lib /mnt/code/github/mongoid-grid_fs/test/mongoid-grid_fs_test.rb
-----------------------------------------------------------------------------------------------------------------------
Run options:

# Running tests:

[14/17] #<Class:0x007f90b032ec48>#test_00013_iterating-each-chunk-having-file-size-more-than-42mb = 0.02 s
1) Failure:
test_00013_iterating-each-chunk-having-file-size-more-than-42mb(#<Class:0x007f90b032ec48>) [/mnt/code/github/mongoid-grid_fs/test/mongoid-grid_fs_test.rb:173]:
assert()

Finished tests in 0.568828s, 29.8860 tests/s, 188.1062 assertions/s.
17 tests, 107 assertions, 1 failures, 0 errors, 0 skips

ruby -v: ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]
-----------------------------------------------------------------------------------------------------------------------
@1 <= FAILURE
-----------------------------------------------------------------------------------------------------------------------
```

After this patch:

```
$ bundle exec rake test

=======================================================================================================================
@1 => ruby -I ./lib -I ./test/lib /mnt/code/github/mongoid-grid_fs/test/mongoid-grid_fs_test.rb
-----------------------------------------------------------------------------------------------------------------------
Run options:

# Running tests:

Finished tests in 1.715598s, 9.9091 tests/s, 63.5347 assertions/s.
17 tests, 109 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]
-----------------------------------------------------------------------------------------------------------------------
@1 <= SUCCESS
-----------------------------------------------------------------------------------------------------------------------
```
