### PR TITLE
Check for Moped::BSON to be defined instead for Moped

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -214,7 +214,7 @@
             raise
           end
 
-          if defined?(Moped)
+          if defined?(Moped::BSON)
             def binary_for(*buf)
               Moped::BSON::Binary.new(:generic, buf.join)
             end
@@ -449,7 +449,7 @@
           self.default_collection_name = "#{ prefix }.chunks"
 
           field(:n, :type => Integer, :default => 0)
-          field(:data, :type => (defined?(Moped) ? Moped::BSON::Binary : BSON::Binary))
+          field(:data, :type => (defined?(Moped::BSON) ? Moped::BSON::Binary : BSON::Binary))
 
           belongs_to(:file, :foreign_key => :files_id, :class_name => file_model_name)
 

--- a/test/mongoid-grid_fs_test.rb
+++ b/test/mongoid-grid_fs_test.rb
@@ -232,7 +232,7 @@ Testing Mongoid::GridFs do
 
 protected
   def object_id_re
-    object_id = defined?(Moped) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
+    object_id = defined?(Moped::BSON) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
 
     %r| \w{#{ object_id.to_s.size }} |iomx
   end


### PR DESCRIPTION
Check for Moped::BSON to be defined as current Moped 2 does not have BSON anymore
