### PR TITLE
Deal with BSON namespace change in Mongoid 4.0

### DIFF
--- a/gemfiles/mongoid-4.0.gemfile
+++ b/gemfiles/mongoid-4.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", github: "rails/rails", branch: "master"
+gem "rails"
 gem "mongoid", github: "mongoid/mongoid", branch: "master"
 
 gemspec path: "../"

--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -214,13 +214,19 @@
             raise
           end
 
-          if defined?(Moped)
+          if defined?(Moped::BSON)
             def binary_for(*buf)
               Moped::BSON::Binary.new(:generic, buf.join)
             end
           else
-            def binary_for(buf)
-              BSON::Binary.new(buf.bytes.to_a)
+            if BSON::VERSION >= '2.0.0'
+              def binary_for(buf)
+                BSON::Binary.new(buf)
+              end
+            else
+              def binary_for(buf)
+                BSON::Binary.new(buf.bytes.to_a)
+              end
             end
           end
 
@@ -449,7 +455,7 @@
           self.default_collection_name = "#{ prefix }.chunks"
 
           field(:n, :type => Integer, :default => 0)
-          field(:data, :type => (defined?(Moped) ? Moped::BSON::Binary : BSON::Binary))
+          field(:data, :type => (defined?(Moped::BSON) ? Moped::BSON::Binary : BSON::Binary))
 
           belongs_to(:file, :foreign_key => :files_id, :class_name => file_model_name)
 

--- a/test/mongoid-grid_fs_test.rb
+++ b/test/mongoid-grid_fs_test.rb
@@ -232,7 +232,7 @@ Testing Mongoid::GridFs do
 
 protected
   def object_id_re
-    object_id = defined?(Moped) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
+    object_id = defined?(Moped::BSON) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
 
     %r| \w{#{ object_id.to_s.size }} |iomx
   end


### PR DESCRIPTION
Mongoid 4.0 no longer uses `Moped::BSON` but bson-ruby's `BSON`, which makes our tests not runnable.
This pull request try to solve it by checking existence of constant `Moped::BSON`.
