### PR TITLE
Mongoid has refactored session options. Getting undefined method `default_collection_name=' 

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -305,7 +305,7 @@
             attr_accessor :defaults
           end
 
-          self.default_collection_name = "#{ prefix }.files"
+          store_in collection: "#{ prefix }.files"
           self.defaults = Defaults.new
 
           self.defaults.chunkSize = 4 * (mb = 2**20)
@@ -445,7 +445,7 @@
             attr_accessor :namespace
           end
 
-          self.default_collection_name = "#{ prefix }.chunks"
+          store_in collection: "#{ prefix }.chunks"
 
           field(:n, :type => Integer, :default => 0)
           field(:data, :type => (defined?(Moped::BSON) ? Moped::BSON::Binary : BSON::Binary))


### PR DESCRIPTION
Commit mongoid/mongoid@cc7a0e7 (master) has removed `default_collection_name`. I have made the fix for this. However, the test case for collection_name fails because the collection name is internally stored as a Symbol and not a string.
