### PR TITLE
use store_in instead of default_collection_name

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -305,7 +305,8 @@
             attr_accessor :defaults
           end
 
-          self.default_collection_name = "#{ prefix }.files"
+          self.store_in :collection => "#{ prefix }.files"
+
           self.defaults = Defaults.new
 
           self.defaults.chunkSize = 4 * (mb = 2**20)
@@ -445,7 +446,7 @@
             attr_accessor :namespace
           end
 
-          self.default_collection_name = "#{ prefix }.chunks"
+          self.store_in :collection => "#{ prefix }.chunks"
 
           field(:n, :type => Integer, :default => 0)
           field(:data, :type => (defined?(Moped::BSON) ? Moped::BSON::Binary : BSON::Binary))

--- a/test/mongoid-grid_fs_test.rb
+++ b/test/mongoid-grid_fs_test.rb
@@ -193,8 +193,8 @@ Testing Mongoid::GridFs do
   context 'namespaces' do
     test 'default' do
       assert{ GridFs.namespace.prefix == 'fs' }
-      assert{ GridFs.file_model.collection_name == 'fs.files' }
-      assert{ GridFs.chunk_model.collection_name == 'fs.chunks' }
+      assert{ GridFs.file_model.collection_name.to_s == 'fs.files' }
+      assert{ GridFs.chunk_model.collection_name.to_s == 'fs.chunks' }
     end
 
     test 'new' do
@@ -203,10 +203,10 @@ Testing Mongoid::GridFs do
       assert{ ns.prefix == 'ns' }
 
       assert{ ns.file_model < Mongoid::Document }
-      assert{ ns.file_model.collection_name == 'ns.files' }
+      assert{ ns.file_model.collection_name.to_s == 'ns.files' }
 
       assert{ ns.chunk_model < Mongoid::Document }
-      assert{ ns.chunk_model.collection_name == 'ns.chunks' }
+      assert{ ns.chunk_model.collection_name.to_s == 'ns.chunks' }
 
       assert{ ns.file_model.destroy_all }
 


### PR DESCRIPTION
`self.default_collection_name` doesn't exists anymore on mongoid 4(master). We should use `store_in` instead, which is also backwards compatible. 
