### PR TITLE
Loosen mime-types gem requirement

### DIFF
--- a/lib/mongoid-grid_fs.rb
+++ b/lib/mongoid-grid_fs.rb
@@ -12,7 +12,7 @@
         def dependencies
           {
             'mongoid'         => [ 'mongoid'         , '>= 3.0', '< 5.0' ] ,
-            'mime/types'      => [ 'mime-types'      , '>= 1.19'] ,
+            'mime/types'      => [ 'mime-types'      , '>= 1.19', '< 3.0'] ,
           }
         end
 

--- a/mongoid-grid_fs.gemspec
+++ b/mongoid-grid_fs.gemspec
@@ -37,7 +37,7 @@ Gem::Specification::new do |spec|
 
     spec.add_dependency(*["mongoid", ">= 3.0", "< 5.0"])
 
-    spec.add_dependency(*["mime-types", ">= 1.19"])
+    spec.add_dependency(*["mime-types", ">= 1.19", "< 3.0"])
 
 
   spec.extensions.push(*[])


### PR DESCRIPTION
Required for 2.0 release of mime-types

No change to `mime-types` method sig that `mongoid-grid_fs` uses.
