### PR TITLE
changed check for old BSON implementation

### DIFF
--- a/lib/mongoid/grid_fs.rb
+++ b/lib/mongoid/grid_fs.rb
@@ -428,7 +428,7 @@ require "mime/types"
           self.store_in :collection => "#{ prefix }.chunks"
 
           field(:n, :type => Integer, :default => 0)
-          field(:data, :type => (defined?(Moped::BSON) ? Moped::BSON::Binary : BSON::Binary))
+          field(:data, :type => (defined?(Moped::BSON::Binary) ? Moped::BSON::Binary : BSON::Binary))
 
           belongs_to(:file, :foreign_key => :files_id, :class_name => file_model_name)
 

--- a/test/mongoid-grid_fs_test.rb
+++ b/test/mongoid-grid_fs_test.rb
@@ -241,7 +241,7 @@ Testing Mongoid::GridFs do
 
 protected
   def object_id_re
-    object_id = defined?(Moped::BSON) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
+    object_id = defined?(Moped::BSON::ObjectId) ? Moped::BSON::ObjectId.new : BSON::ObjectId.new
 
     %r| \w{#{ object_id.to_s.size }} |iomx
   end


### PR DESCRIPTION
It looks like in Mongoid 4.0, Moped::BSON is still defined.  This changes the check to Moped::BSON::Binary, which is what is actually needed and which is not present in Mongoid 4.
