### PR TITLE
Idiomatic use of .gte and .lt - fixes empty chunks issue with mongoid v3...

### DIFF
--- a/lib/mongoid/grid_fs.rb
+++ b/lib/mongoid/grid_fs.rb
@@ -324,7 +324,7 @@ require "mime/types"
             fetched, limit = 0, 7
 
             while fetched < chunks.size
-              chunks.where(:n.lt => fetched+limit, :n.gte => fetched).
+              chunks.lt(n: fetched+limit).gte(n: fetched).
                 order_by([:n, :asc]).each do |chunk|
                   block.call(chunk.to_s)
                 end


### PR DESCRIPTION
....1.6 / moped v1.5.2
