### PR TITLE
Support for mongoid 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ gemfile:
   - gemfiles/mongoid-4.0.gemfile
   - gemfiles/mongoid-5.0.gemfile
   - gemfiles/mongoid-6.0.gemfile
+  - gemfiles/mongoid-7.0.gemfile
 
 before_script:
   - bundle exec danger

--- a/gemfiles/mongoid-7.0.gemfile
+++ b/gemfiles/mongoid-7.0.gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.0'
+gem 'mongoid', '~> 7.0.0'
+
+gemspec path: '../'
+
+group :development, :test do
+  gem 'rubocop', '0.45.0'
+end
+
+group :test do
+  gem 'mongoid-danger', '~> 0.1.0', require: false
+end

--- a/mongoid-grid_fs.gemspec
+++ b/mongoid-grid_fs.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files   = Dir['test/**/*']
   spec.require_path = 'lib'
 
-  spec.add_dependency 'mongoid',    '>= 3.0', '< 7.0'
+  spec.add_dependency 'mongoid',    '>= 3.0', '<= 7.0'
   spec.add_dependency 'mime-types', '>= 1.0', '< 4.0'
   spec.add_development_dependency 'minitest', '>= 5.7.0', '< 6.0'
 end


### PR DESCRIPTION
This should add support for mongoid 7, which did not require changes to the code.
Test suite runs green locally at least 🙂